### PR TITLE
Fixes a typo preventing build

### DIFF
--- a/source/documentation/information/mojgithubenteprise.html.md.erb
+++ b/source/documentation/information/mojgithubenteprise.html.md.erb
@@ -1,8 +1,0 @@
----
-owner_slack: "#operations-engineering-alerts"
-title: MoJ GitHub Enteprise Management
-last_reviewed_on: 2023-08-02
-review_in: 6 months
----
-
-# MoJ GitHub Enteprise Management

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -19,7 +19,7 @@ These guides provide information and details about the services that Operations 
 ## What we support
 
 *[1Password](documentation/services/1password.html)
-*[CircleCI](documentation/services/circlci.html)
+*[CircleCI](documentation/services/circleci.html)
 *[Domain Managment](documentation/services/domainmgt.html)
 *[GitHub](documentation/services/github.html)
 *[Moj Auth0 Account](documentation/services/auth0account.html)


### PR DESCRIPTION
Quick fix to correct a typo which is stopping a document from being found and stopping the build.

Also deleted a duplicate file.