### PR TITLE
Adds info to some user guide pages

### DIFF
--- a/source/documentation/information/contact.html.md.erb
+++ b/source/documentation/information/contact.html.md.erb
@@ -6,3 +6,9 @@ review_in: 6 months
 ---
 
 # How to contact Operations Engineering
+
+Our primary contact channel is [#ask-operations-engineering](https://mojdt.slack.com/archives/C01BUKJSZD4). 
+Please use this channel to contact the team, provide feedback on our services, or to request support from 
+the Operations Engineering Team.
+
+You can also send email to: operations-engineering@digital.justice.gov.uk

--- a/source/documentation/information/githubcommunity.html.md.erb
+++ b/source/documentation/information/githubcommunity.html.md.erb
@@ -1,0 +1,8 @@
+---
+owner_slack: "#operations-engineering-alerts"
+title: GitHub Community Channel
+last_reviewed_on: 2023-08-02
+review_in: 6 months
+---
+
+# GitHub Community Channel

--- a/source/documentation/information/operations-engineering.html.md.erb
+++ b/source/documentation/information/operations-engineering.html.md.erb
@@ -6,3 +6,9 @@ review_in: 6 months
 ---
 
 # Who Are Operations Engineering?
+
+Operations Engineering buy, build, and run tools to help build and operate software at scale.
+
+While we will use the Cloud Platform for developing and hosting our services, as a team the 
+tools and standards we create will be made readily available across multiple platforms and 
+hosting services across the organisation.

--- a/source/documentation/information/our-alliance.html.md.erb
+++ b/source/documentation/information/our-alliance.html.md.erb
@@ -7,4 +7,26 @@ review_in: 6 months
 
 # Our Alliance
 
-Some text
+As a team, we regularly discuss and decide on our alliance, and document these openly and publicly.
+
+Our alliance is as follows (in alphabetical order):
+
+    We agree that there are no stupid question
+    We aim to automate
+    We appreciate work takes time
+    We are respectful of others time
+    We communicate out loud and in the open about what we are working on in our team Slack channel (#operations-engineering-team)
+    We encourage and take time to learn new stuff
+    We ensure everyone is aware of any risks/blockers
+    We have a no blame culture
+    We have fun and don’t take ourselves too seriously
+    We help each other out
+    We highlight team successes
+    We keep tickets up to date
+    We put team member wellbeing first
+    We take joint ownership of the work that we do
+    We work remote first
+    We work in a transparent way
+    We are aware of our long term goals
+    We promote internal knowledge sharing
+    We ensure high quality standards in our work

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -35,6 +35,7 @@ These guides provide information and details about the services that Operations 
 ## Information
 
 * [GitHub Standards](documentation/information/githubstandards.html)
+* [Github Community](documentation/information/gihubcommunity.html)
 * [MoJ Acronyms](documentation/information/mojacronyms.html)
 * [MoJ Documentation Template Repository](documentation/information/mojrepotemplatedocs.html)
 * [MoJ Organisational Charts](documentation/information/mojorgcharts.html)


### PR DESCRIPTION
This PR adds some basic info about the Operations Engineering team to the relevant User Guides pages.

- added GitHub Community Channel page
- added info to contact page
- added info to alliance page
- added info to who we are page